### PR TITLE
fix(cli): 优化生成结构体的字段标签

### DIFF
--- a/cmd/maltose/internal/gen/common.go
+++ b/cmd/maltose/internal/gen/common.go
@@ -115,13 +115,13 @@ func dbTypeToGo(column gorm.ColumnType) string {
 
 // makeTags creates gorm and json struct tags for a field.
 func makeTags(column gorm.ColumnType) string {
-	return fmt.Sprintf(`gorm:"column:%s" json:"%s"`, column.Name(), strcase.ToLowerCamel(column.Name()))
+	return fmt.Sprintf(`gorm:"column:%s"`, column.Name())
 }
 
 // makeRemarks creates remarks for a field.
 func makeRemarks(column gorm.ColumnType) string {
 	comment, ok := column.Comment()
-	if !ok {
+	if !ok || comment == "" {
 		return ""
 	}
 	return fmt.Sprintf("// %s", comment)

--- a/cmd/maltose/internal/gen/template.go
+++ b/cmd/maltose/internal/gen/template.go
@@ -345,20 +345,4 @@ type {{.DaoName}} struct {
 		}
 	}
 	`
-
-	// TplGenModel is the template for generating model files.
-	TplGenModel = `// =================================================================================
-	// Code generated and maintained by Maltose tool. DO NOT EDIT.
-	// =================================================================================
-	package {{.PackageName}}
-
-	import "time"
-
-	// {{.StructName}} is the model for the {{.Table}} table.
-	type {{.StructName}} struct {
-		{{range .Fields}}
-		{{.StructName}} {{.Type}} ` + "`gorm:\"{{.Gorm}}\" json:\"{{.Json}}\"`" + ` // {{.Comment}}
-		{{end}}
-	}
-	`
 )


### PR DESCRIPTION
修复了代码生成器逻辑，在生成模型结构体时，不再添加多余的 json 标签，使生成的代码更简洁。