### PR TITLE
fix: 修正 mdb 配置反序列化

### DIFF
--- a/database/mdb/mdb_config.go
+++ b/database/mdb/mdb_config.go
@@ -59,7 +59,7 @@ func defaultConfig() *Config {
 }
 
 func (c *Config) SetConfigWithMap(config map[string]any) error {
-	return mconv.ToStructE(config, &c)
+	return mconv.ToStructE(config, c)
 }
 
 func (c *Config) SetLogger(logger *mlog.Logger) {


### PR DESCRIPTION
修正 SetConfigWithMap 方法中的参数传递，确保配置正确反序列化