### PR TITLE
fix: 补充默认数据库配置

### DIFF
--- a/database/mdb/mdb_config.go
+++ b/database/mdb/mdb_config.go
@@ -45,7 +45,7 @@ type Config struct {
 func defaultConfig() *Config {
 	return &Config{
 		Type:              "mysql",
-		Host:              "3306",
+		Port:              "3306",
 		MaxIdleTime:       10 * time.Second,
 		MaxIdleConnection: 10,
 		MaxOpenConnection: 100,


### PR DESCRIPTION
修正数据库配置中的 Host 字段为 Port，以确保正确配置数据库连接