### PR TITLE
feat(mlog): 全面重构日志模块并提升易用性

### DIFF
--- a/os/mlog/mlog.go
+++ b/os/mlog/mlog.go
@@ -28,9 +28,6 @@ const (
 	defaultLevel      = InfoLevel
 )
 
-// Fields is a map of string keys to any values.
-type Fields []Field
-
 var (
 	// Ensure Logger implements ILogger interface
 	_ ILogger = &Logger{}

--- a/os/mlog/mlog_api.go
+++ b/os/mlog/mlog_api.go
@@ -71,6 +71,11 @@ func AddHook(hook Hook) {
 	defaultLogger.AddHook(hook)
 }
 
+// RemoveHook removes a hook from the logger.
+func RemoveHook(hookName string) {
+	defaultLogger.RemoveHook(hookName)
+}
+
 // Close closes the logger and its underlying resources.
 func Close() error {
 	return defaultLogger.Close()

--- a/os/mlog/mlog_api_config.go
+++ b/os/mlog/mlog_api_config.go
@@ -61,6 +61,13 @@ func SetCtxKeys(keys []string) {
 	})
 }
 
+// SetCaller sets the caller.
+func SetCaller(enabled bool) {
+	defaultLogger.SetConfigWithMap(map[string]any{
+		"caller": enabled,
+	})
+}
+
 // SetLevel sets the log level.
 func SetLevel(level Level) {
 	defaultLogger.SetLevel(level)

--- a/os/mlog/mlog_config.go
+++ b/os/mlog/mlog_config.go
@@ -11,12 +11,12 @@ type Config struct {
 	Level Level `mconv:"level"`
 	// TimeFormat is the log time format.
 	TimeFormat string `mconv:"time_format"`
-	// Format is the log format.
+	// Format is the log format. Only support "json" and "text".
 	Format string `mconv:"format"`
 	// Caller is the add caller.
 	// If true, the caller will be added to the log.
 	Caller bool `mconv:"caller"`
-	// Path is the log file path.
+	// Filepath is the log file path.
 	// e.g., /var/log/app.log or /var/log/app.{YYYYmmdd}.log
 	Filepath string `mconv:"filepath"`
 	// MaxSize is the maximum size in megabytes of the log file before it gets rotated.
@@ -31,7 +31,7 @@ type Config struct {
 	// Stdout is the stdout print.
 	Stdout bool `mconv:"stdout"`
 	// CtxKeys is the context keys to extract.
-	CtxKeys map[string]any `mconv:"ctx_keys"`
+	CtxKeys []string `mconv:"ctx_keys"`
 }
 
 // defaultConfig returns the default configuration.
@@ -46,7 +46,7 @@ func defaultConfig() *Config {
 		MaxAge:     7,
 		MaxBackups: 10,
 		Stdout:     true,
-		CtxKeys:    map[string]any{},
+		CtxKeys:    []string{},
 	}
 }
 

--- a/os/mlog/mlog_entry.go
+++ b/os/mlog/mlog_entry.go
@@ -19,12 +19,6 @@ type Entry struct {
 	fields Fields
 }
 
-// AddField adds a field to the entry.
-func (e *Entry) AddField(field Field) *Entry {
-	e.fields = append(e.fields, field)
-	return e
-}
-
 // SetMsg sets the message of the entry.
 func (e *Entry) SetMsg(msg string) *Entry {
 	e.msg = msg
@@ -36,9 +30,21 @@ func (e *Entry) GetMsg() string {
 	return e.msg
 }
 
+// AddField adds a field to the entry.
+func (e *Entry) AddField(field Field) *Entry {
+	e.fields = append(e.fields, field)
+	return e
+}
+
 // GetFields returns the fields of the entry.
 func (e *Entry) GetFields() Fields {
 	return e.fields
+}
+
+// SetFields sets the fields of the entry.
+func (e *Entry) SetFields(fields Fields) *Entry {
+	e.fields = fields
+	return e
 }
 
 // GetContext returns the context of the entry.
@@ -52,6 +58,7 @@ func (e *Entry) SetContext(ctx context.Context) *Entry {
 	return e
 }
 
+// Reset resets the entry.
 func (e *Entry) reset() *Entry {
 	e.ctx = nil
 	e.msg = ""

--- a/os/mlog/mlog_field.go
+++ b/os/mlog/mlog_field.go
@@ -19,6 +19,9 @@ type Field struct {
 	Interface any
 }
 
+// Fields is a slice of Field.
+type Fields []Field
+
 // Any takes a key and an arbitrary value and chooses the best way to represent
 // them as a field.
 func Any(key string, value any) Field {

--- a/os/mlog/mlog_hook.go
+++ b/os/mlog/mlog_hook.go
@@ -36,5 +36,4 @@ func (l *Logger) RemoveHook(hookName string) {
 			break
 		}
 	}
-
 }

--- a/os/mlog/mlog_hook_internal.go
+++ b/os/mlog/mlog_hook_internal.go
@@ -28,7 +28,7 @@ func (h *traceHook) Fire(entry *Entry) {
 
 // ctxHook is a hook that extracts values from context.
 type ctxHook struct {
-	keys map[string]any
+	keys []string
 }
 
 func (h *ctxHook) Name() string { return ctxHookName }
@@ -39,9 +39,9 @@ func (h *ctxHook) Fire(entry *Entry) {
 	if entry.GetContext() == nil {
 		return
 	}
-	for attrKey, ctxKey := range h.keys {
+	for _, ctxKey := range h.keys {
 		if value := entry.GetContext().Value(ctxKey); value != nil {
-			entry.AddField(Any(attrKey, value))
+			entry.AddField(Any(ctxKey, value))
 		}
 	}
 }

--- a/os/mlog/mlog_logger_internal.go
+++ b/os/mlog/mlog_logger_internal.go
@@ -91,6 +91,8 @@ func (l *Logger) log(ctx context.Context, level Level, msg string, fields ...Fie
 		}
 	}
 
+	// NOTE: This is a zero-cost cast that relies on mlog.Field having the same memory layout as zapcore.Field.
+	// Be cautious when upgrading zap or changing mlog.Field definition.
 	zapFields := *(*[]zap.Field)(unsafe.Pointer(&entry.fields))
 	switch level {
 	case DebugLevel:

--- a/os/mlog/z_mlog_test.go
+++ b/os/mlog/z_mlog_test.go
@@ -127,18 +127,13 @@ func TestLogger_DynamicLevelChange(t *testing.T) {
 
 // TestLogger_Hooks verifies that Trace and CtxKeys hooks correctly inject fields.
 func TestLogger_Hooks(t *testing.T) {
-	type contextKey string
-	const requestIDKey contextKey = "request_id"
-
 	logger, logPath := setupTestLogger(t, mlog.Config{
-		CtxKeys: map[string]any{
-			"request_id": requestIDKey,
-		},
+		CtxKeys: []string{"request_id"},
 	})
 
 	ctx := mctx.New()
 	ctx, _ = mtrace.WithTraceID(ctx, "12345678901234567890123456789012")
-	ctx = context.WithValue(ctx, requestIDKey, "req-abcde")
+	ctx = context.WithValue(ctx, "request_id", "req-abcde")
 
 	logger.Infow(ctx, "testing hooks")
 	time.Sleep(10 * time.Millisecond)


### PR DESCRIPTION
#### 概述

本次更新对 `mlog` 日志模块进行了一次全面的重构和功能增强。
底层实现已从 **Logrus** 切换为高性能的 **Zap**，并对配置、API 和文件轮转等核心功能进行了优化与完善。

#### 主要变更

*   **核心重构**: 底层从 Logrus 更换为 Zap，显著提升了日志记录性能并减少了内存分配。
*   **配置增强**:
    *   修复了 `CtxKeys` 类型不一致的问题 (`map[string]any` → `[]string`)。
    *   增加了 `Caller` 配置项，用于控制是否记录调用位置。
*   **功能完善**:
    *   文件轮转功能现在支持更灵活的组合式日期占位符，例如 `app-{YYYYMMDD}.log`。
*   **API 补全**:
    *   新增了包级别的 `SetCaller(bool)` 和 `RemoveHook(string)` API，使接口更加完整和对称。
    *   在 `unsafe` 代码处增加了必要的警告注释，提升了代码的可维护性。
*   **文档更新**:
    *   全面重写了 `logging.md` 文档，以匹配新的 Zap 实现和 API。
    *   在文档中增加了关于谨慎使用分钟/秒级日志轮转的明确警告。