### PR TITLE
feat(cli): gen logic 命令现在会自动创建用于服务自动注册的清单文件

### DIFF
--- a/cmd/maltose/cli/logic.go
+++ b/cmd/maltose/cli/logic.go
@@ -27,7 +27,6 @@ var logicCmd = &cobra.Command{
 			return merror.Wrap(err, "failed to generate logic file")
 		}
 
-		utils.PrintSuccess("logic_generation_success", nil)
 		return nil
 	},
 }

--- a/cmd/maltose/go.sum
+++ b/cmd/maltose/go.sum
@@ -20,8 +20,8 @@ github.com/go-sql-driver/mysql v1.8.1 h1:LedoTUt/eveggdHS9qUFC1EFSa8bU2+1pZjSRpv
 github.com/go-sql-driver/mysql v1.8.1/go.mod h1:wEBSXgmK//2ZFJyE+qWnIsVGmvmEKlqwuVSjsCm7DZg=
 github.com/go-test/deep v1.0.8 h1:TDsG77qcSprGbC6vTN8OuXp5g+J+b5Pcguhf7Zt61VM=
 github.com/go-test/deep v1.0.8/go.mod h1:5C2ZWiW0ErCdrYzpqxLbTX7MG14M9iiw8DgHncVwcsE=
-github.com/graingo/maltose v0.1.4 h1:YkCMTc9OC04V//V1k/5zS8JaZ69oM5p+4FVD/r7T7yA=
-github.com/graingo/maltose v0.1.4/go.mod h1:q19Fic9YtIbt5KMKRG5lCUcg1uTg+LOoxUXaX/xmWwg=
+github.com/graingo/maltose v0.1.7 h1:KKvYEiIm69l10aNr3kG0YWZjJ93Xo2rzNtNiICGj2iE=
+github.com/graingo/maltose v0.1.7/go.mod h1:6+/8Da6aA6Ku3CFgOFXADwecf4UKRNFc8s2sYJtJvdo=
 github.com/iancoleman/strcase v0.3.0 h1:nTXanmYxhfFAMjZL34Ov6gkzEsSJZ5DbhxWjvSASxEI=
 github.com/iancoleman/strcase v0.3.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=

--- a/cmd/maltose/i18n/en.json
+++ b/cmd/maltose/i18n/en.json
@@ -58,5 +58,7 @@
   "not_have_service_interface": "The file does not contain a service interface, skipping logic generation.",
   "logic_file_uptodate": "⏩ Logic file {{.File}} is up to date, skipping.",
   "logic_methods_appended": "✅ Appended {{.Count}} new methods to {{.File}}.",
-  "logic_gen_skip_method_bad_signature": "⚠️ Skipping method '{{.Method}}' in service '{{.Service}}' due to unsupported signature. Supported formats are:\n  - Method(ctx context.Context) error\n  - Method(ctx context.Context) (*Res, error)\n  - Method(ctx context.Context, req *Req) error\n  - Method(ctx context.Context, req *Req) (*Res, error)"
+  "logic_manifest_generated": "Generated logic manifest file: {{.Path}}",
+  "logic_manifest_hint": "Hint: Please add `_ \"{{.ModulePath}}/internal/logic\"` to your main.go to enable automatic service registration.",
+  "logic_gen_skip_method_bad_signature": "⚠️ Skipping method '{{.Method}}' in service '{{.Service}}' due to unsupported signature. Supported formats are:\n  - Method(context.Context) error\n  - Method(context.Context) (*Output, error)\n  - Method(context.Context, *Input) error\n  - Method(context.Context, *Input) (*Output, error)"
 }

--- a/cmd/maltose/i18n/zh.json
+++ b/cmd/maltose/i18n/zh.json
@@ -58,5 +58,7 @@
   "not_have_service_interface": "当前文件没有 service 接口, 跳过 logic 生成。",
   "logic_file_uptodate": "⏩ Logic 文件 {{.File}} 已是最新, 无需改动。",
   "logic_methods_appended": "✅ 已向 {{.File}} 追加 {{.Count}} 个新方法。",
-  "logic_gen_skip_method_bad_signature": "⚠️ 因方法 '{{.Method}}' (服务 '{{.Service}}') 签名不支持，已跳过。支持的格式为:\n  - Method(ctx context.Context) error\n  - Method(ctx context.Context) (*Res, error)\n  - Method(ctx context.Context, req *Req) error\n  - Method(ctx context.Context, req *Req) (*Res, error)"
+  "logic_manifest_generated": "已生成 logic 清单文件: {{.Path}}",
+  "logic_manifest_hint": "提示: 请在你的 main.go 文件中添加 `_ \"{{.ModulePath}}/internal/logic\"` 来启用服务自动注册。",
+  "logic_gen_skip_method_bad_signature": "⚠️ 因方法 '{{.Method}}' (服务 '{{.Service}}') 签名不支持，已跳过。支持的格式为:\n  - Method(context.Context) error\n  - Method(context.Context) (*Output, error)\n  - Method(context.Context, *Input) error\n  - Method(context.Context, *Req) (*Res, error)"
 }

--- a/cmd/maltose/internal/gen/template.go
+++ b/cmd/maltose/internal/gen/template.go
@@ -345,4 +345,17 @@ type {{.DaoName}} struct {
 		}
 	}
 	`
+
+	// TplGenLogicManifest is the template for the main logic file that imports all logic packages.
+	TplGenLogicManifest = `// =================================================================================
+// Code generated and maintained by Maltose tool. DO NOT EDIT.
+// =================================================================================
+package logic
+
+import (
+	{{- range .Packages }}
+	_ "{{.}}"
+	{{- end }}
+)
+`
 )

--- a/errors/mcode/mcode.go
+++ b/errors/mcode/mcode.go
@@ -12,26 +12,26 @@ var (
 	CodeNil                      = localCode{-1, "", nil}
 	CodeOK                       = localCode{0, "OK", nil}
 	CodeUnknown                  = localCode{1, "Unknown", nil}
-	CodeInvalidRequest           = localCode{100, "Invalid Request", nil}
-	CodeInvalidParameter         = localCode{101, "Invalid Parameter", nil}
-	CodeMissingParameter         = localCode{102, "Missing Parameter", nil}
-	CodeValidationFailed         = localCode{103, "Validation Failed", nil}
-	CodeNotFound                 = localCode{104, "Not Found", nil}
-	CodeNotAuthorized            = localCode{105, "Not Authorized", nil}
-	CodeForbidden                = localCode{106, "Forbidden", nil}
-	CodeInternalError            = localCode{200, "Internal Error", nil}
-	CodeDbOperationError         = localCode{201, "Database Operation Error", nil}
-	CodeInternalPanic            = localCode{202, "Internal Panic", nil}
-	CodeServerBusy               = localCode{203, "Server Busy", nil}
-	CodeRateLimitExceeded        = localCode{204, "Rate Limit Exceeded", nil}
-	CodeInvalidOperation         = localCode{300, "Invalid Operation", nil}
-	CodeInvalidConfiguration     = localCode{301, "Invalid Configuration", nil}
-	CodeMissingConfiguration     = localCode{302, "Missing Configuration", nil}
-	CodeNotImplemented           = localCode{303, "Not Implemented", nil}
-	CodeNotSupported             = localCode{304, "Not Supported", nil}
-	CodeOperationFailed          = localCode{305, "Operation Failed", nil}
-	CodeSecurityReason           = localCode{400, "Security Reason", nil}
-	CodeBusinessValidationFailed = localCode{500, "Business Validation Failed", nil}
+	CodeInvalidRequest           = localCode{1000, "Invalid Request", nil}
+	CodeInvalidParameter         = localCode{1001, "Invalid Parameter", nil}
+	CodeMissingParameter         = localCode{1002, "Missing Parameter", nil}
+	CodeValidationFailed         = localCode{1003, "Validation Failed", nil}
+	CodeNotFound                 = localCode{1004, "Not Found", nil}
+	CodeNotAuthorized            = localCode{1005, "Not Authorized", nil}
+	CodeForbidden                = localCode{1006, "Forbidden", nil}
+	CodeInternalError            = localCode{2000, "Internal Error", nil}
+	CodeDbOperationError         = localCode{2001, "Database Operation Error", nil}
+	CodeInternalPanic            = localCode{2002, "Internal Panic", nil}
+	CodeServerBusy               = localCode{2003, "Server Busy", nil}
+	CodeRateLimitExceeded        = localCode{2004, "Rate Limit Exceeded", nil}
+	CodeInvalidOperation         = localCode{3000, "Invalid Operation", nil}
+	CodeInvalidConfiguration     = localCode{3001, "Invalid Configuration", nil}
+	CodeMissingConfiguration     = localCode{3002, "Missing Configuration", nil}
+	CodeNotImplemented           = localCode{3003, "Not Implemented", nil}
+	CodeNotSupported             = localCode{3004, "Not Supported", nil}
+	CodeOperationFailed          = localCode{3005, "Operation Failed", nil}
+	CodeSecurityReason           = localCode{4000, "Security Reason", nil}
+	CodeBusinessValidationFailed = localCode{5000, "Business Validation Failed", nil}
 )
 
 // New creates a new error code.

--- a/net/mhttp/mhttp_middleware_internal.go
+++ b/net/mhttp/mhttp_middleware_internal.go
@@ -5,6 +5,8 @@ import (
 	"time"
 
 	"github.com/graingo/maltose"
+	"github.com/graingo/maltose/errors/mcode"
+	"github.com/graingo/maltose/errors/merror"
 	"github.com/graingo/maltose/net/mtrace"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -67,7 +69,7 @@ func internalMiddlewareRecovery() MiddlewareFunc {
 				// record error log
 				r.Logger().Errorf(r.Request.Context(), nil, fmt.Sprintf("Panic recovered: %s", err))
 				// return 500 error
-				r.String(500, "Internal Server Error")
+				r.SetHandlerResponse(merror.NewCodef(mcode.CodeInternalError, "Panic recovered: %s", err))
 			}
 		}()
 		r.Next()


### PR DESCRIPTION
本次变更增强了 `maltose gen logic` 命令，使其能够自动在 `internal/logic/logic.go` 路径下生成一个清单文件。

### 主要变更:
- `gen logic` 命令现在会追踪所有生成的 logic 包。
- 它会创建或覆盖 `internal/logic/logic.go` 文件，其中包含对这些包的副作用导入 (`_ "..."`)。
- 这使得 logic 服务的自动注册成为可能，简化了项目设置和模块管理。
- 现在会提示用户在他们的 `main.go` 文件中添加一个导入 (`_ "<module>/internal/logic"`) 来激活此机制。