### PR TITLE
refactor: 重构中间件核心机制并增强日志可观察性

### DIFF
--- a/net/mclient/mclient_middleware_internal.go
+++ b/net/mclient/mclient_middleware_internal.go
@@ -78,12 +78,6 @@ func internalMiddlewareMetric() MiddlewareFunc {
 func internalMiddlewareTrace() MiddlewareFunc {
 	return func(next HandlerFunc) HandlerFunc {
 		return func(req *Request) (*Response, error) {
-			// if using default provider, skip complex tracing
-			if !mtrace.IsUsingMaltoseProvider() {
-				ctx := req.Request.Context()
-				req.Request = req.Request.WithContext(ctx)
-				return next(req)
-			}
 			ctx := req.Request.Context()
 
 			// create tracer

--- a/net/mclient/mclient_middleware_log.go
+++ b/net/mclient/mclient_middleware_log.go
@@ -9,7 +9,7 @@ import (
 	"github.com/graingo/maltose/os/mlog"
 )
 
-const maxBodySize = 512
+const maxBodySize = 1024
 
 // MiddlewareLog creates a middleware that logs request and response details in two steps:
 // 1. Before the request is sent ("started").

--- a/net/mclient/mclient_middleware_log.go
+++ b/net/mclient/mclient_middleware_log.go
@@ -9,7 +9,7 @@ import (
 	"github.com/graingo/maltose/os/mlog"
 )
 
-const maxBodySize = -1
+var LogMaxBodySize int = -1
 
 // MiddlewareLog creates a middleware that logs request and response details in two steps:
 // 1. Before the request is sent ("started").
@@ -41,7 +41,7 @@ func MiddlewareLog(logger *mlog.Logger) MiddlewareFunc {
 				mlog.String("url", req.Request.URL.String()),
 			}
 			if len(reqBodyBytes) > 0 {
-				requestFields = append(requestFields, mlog.String("request_body", getBodyString(reqBodyBytes, maxBodySize)))
+				requestFields = append(requestFields, mlog.String("request_body", getBodyString(reqBodyBytes, LogMaxBodySize)))
 			}
 
 			l.Infow(ctx, "http client request started", requestFields...)
@@ -69,7 +69,7 @@ func MiddlewareLog(logger *mlog.Logger) MiddlewareFunc {
 				bodyBytes, _ := io.ReadAll(resp.Body)
 				resp.Body = io.NopCloser(bytes.NewBuffer(bodyBytes)) // Restore body for next handler
 				if len(bodyBytes) > 0 {
-					finalFields = append(finalFields, mlog.String("response_body", getBodyString(bodyBytes, maxBodySize)))
+					finalFields = append(finalFields, mlog.String("response_body", getBodyString(bodyBytes, LogMaxBodySize)))
 				}
 			}
 

--- a/net/mclient/mclient_middleware_log.go
+++ b/net/mclient/mclient_middleware_log.go
@@ -9,7 +9,7 @@ import (
 	"github.com/graingo/maltose/os/mlog"
 )
 
-const maxBodySize = 1024
+const maxBodySize = -1
 
 // MiddlewareLog creates a middleware that logs request and response details in two steps:
 // 1. Before the request is sent ("started").
@@ -88,6 +88,9 @@ func MiddlewareLog(logger *mlog.Logger) MiddlewareFunc {
 func getBodyString(body []byte, limit int) string {
 	if len(body) == 0 {
 		return ""
+	}
+	if limit < 0 { // no limit
+		return string(body)
 	}
 	if len(body) > limit {
 		return string(body[:limit]) + "..."

--- a/net/mclient/mclient_middleware_log.go
+++ b/net/mclient/mclient_middleware_log.go
@@ -11,8 +11,10 @@ import (
 
 const maxBodySize = 512
 
-// MiddlewareLog creates a middleware that logs request and response details
-// using the provided logger.
+// MiddlewareLog creates a middleware that logs request and response details in two steps:
+// 1. Before the request is sent ("started").
+// 2. After the request is completed ("finished" or "error").
+// This allows for better observability, especially for hanging requests.
 func MiddlewareLog(logger *mlog.Logger) MiddlewareFunc {
 	if logger == nil {
 		return func(next HandlerFunc) HandlerFunc {
@@ -22,33 +24,59 @@ func MiddlewareLog(logger *mlog.Logger) MiddlewareFunc {
 
 	return func(next HandlerFunc) HandlerFunc {
 		return func(req *Request) (*Response, error) {
-			start := time.Now()
 			ctx := req.Context()
-
-			// Add component to logger for this middleware instance
 			l := logger.With(mlog.String(maltose.COMPONENT, "mclient"))
+
+			// --- Step 1: Log request start ---
 
 			var reqBodyBytes []byte
 			if req.Body != nil {
+				// Safely read request body for logging and then restore it
 				reqBodyBytes, _ = io.ReadAll(req.Body)
 				req.Body = io.NopCloser(bytes.NewBuffer(reqBodyBytes))
 			}
 
-			// Execute request
+			requestFields := mlog.Fields{
+				mlog.String("method", req.Request.Method),
+				mlog.String("url", req.Request.URL.String()),
+			}
+			if len(reqBodyBytes) > 0 {
+				requestFields = append(requestFields, mlog.String("request_body", getBodyString(reqBodyBytes, maxBodySize)))
+			}
+
+			l.Infow(ctx, "http client request started", requestFields...)
+
+			// --- Step 2: Execute request and log completion ---
+
+			start := time.Now()
 			resp, err := next(req)
 			duration := time.Since(start)
 
-			fields := buildLogFields(req, resp, duration, reqBodyBytes)
+			// The final log should contain all information for context.
+			// Start with the initial request fields.
+			finalFields := append(requestFields, mlog.Float64("duration_ms", float64(duration.Nanoseconds())/1e6))
 
 			if err != nil {
-				l.Errorw(ctx, err, "http client request error", fields...)
+				// Handle network or other errors before getting a response
+				finalFields = append(finalFields, mlog.Err(err))
+				l.Errorw(ctx, err, "http client request error", finalFields...)
 				return resp, err
 			}
 
+			// If we got a response, add its details to the log
+			finalFields = append(finalFields, mlog.Int("status", resp.StatusCode))
+			if resp.Body != nil {
+				bodyBytes, _ := io.ReadAll(resp.Body)
+				resp.Body = io.NopCloser(bytes.NewBuffer(bodyBytes)) // Restore body for next handler
+				if len(bodyBytes) > 0 {
+					finalFields = append(finalFields, mlog.String("response_body", getBodyString(bodyBytes, maxBodySize)))
+				}
+			}
+
 			if resp.StatusCode >= 400 {
-				l.Errorw(ctx, err, "http client request finished with error status", fields...)
+				l.Warnw(ctx, "http client request finished with error status", finalFields...)
 			} else {
-				l.Infow(ctx, "http client request finished", fields...)
+				l.Infow(ctx, "http client request finished", finalFields...)
 			}
 
 			return resp, nil
@@ -56,41 +84,13 @@ func MiddlewareLog(logger *mlog.Logger) MiddlewareFunc {
 	}
 }
 
-// buildLogFields extracts and builds a map of fields for logging.
-func buildLogFields(r *Request, resp *Response, duration time.Duration, reqBodyBytes []byte) mlog.Fields {
-	fields := mlog.Fields{
-		mlog.Float64("duration_ms", float64(duration.Nanoseconds())/1e6),
-		mlog.String("method", r.Request.Method),
+// getBodyString safely converts a byte slice to a string for logging, with a size limit.
+func getBodyString(body []byte, limit int) string {
+	if len(body) == 0 {
+		return ""
 	}
-
-	if r.Request != nil && r.Request.URL != nil {
-		fields = append(fields, mlog.String("url", r.Request.URL.String()))
-	} else {
-		fields = append(fields, mlog.String("url", "<no url>"))
+	if len(body) > limit {
+		return string(body[:limit]) + "..."
 	}
-
-	// Use the pre-read byte slice instead of trying to read the consumed stream.
-	if len(reqBodyBytes) > 0 {
-		bodyStr := string(reqBodyBytes)
-		if len(bodyStr) > maxBodySize {
-			bodyStr = bodyStr[:maxBodySize] + "..."
-		}
-		fields = append(fields, mlog.String("request_body", bodyStr))
-	}
-
-	if resp != nil {
-		fields = append(fields, mlog.Int("status", resp.StatusCode))
-		// Safely read and log the response body
-		if resp.Body != nil {
-			bodyBytes, _ := io.ReadAll(resp.Body)
-			resp.Body = io.NopCloser(bytes.NewBuffer(bodyBytes)) // Restore body
-			bodyStr := string(bodyBytes)
-			if len(bodyStr) > maxBodySize {
-				bodyStr = bodyStr[:maxBodySize] + "..."
-			}
-			fields = append(fields, mlog.String("response_body", bodyStr))
-		}
-	}
-
-	return fields
+	return string(body)
 }

--- a/net/mhttp/mhttp.go
+++ b/net/mhttp/mhttp.go
@@ -51,9 +51,11 @@ func New(config ...*Config) *Server {
 
 	// initialize root RouterGroup
 	s.RouterGroup = RouterGroup{
-		server:   s,
-		path:     "/",
-		ginGroup: engine.Group("/"),
+		server:      s,
+		path:        "/",
+		ginGroup:    &s.engine.RouterGroup,
+		middlewares: make([]MiddlewareFunc, 0),
+		parent:      nil,
 	}
 
 	// add default middlewares
@@ -63,6 +65,7 @@ func New(config ...*Config) *Server {
 		internalMiddlewareMetric(),
 		internalMiddlewareDefaultResponse(),
 	)
+
 	if s.config.ServerLocale != "" {
 		// register translator
 		s.registerValidateTranslator(s.config.ServerLocale)

--- a/net/mhttp/mhttp_health.go
+++ b/net/mhttp/mhttp_health.go
@@ -15,5 +15,6 @@ func (s *Server) registerHealthCheck(ctx context.Context) {
 			"status": "ok",
 		})
 	})
+
 	s.logger().Infof(ctx, "Health check endpoint registered at %s", s.config.HealthCheck)
 }

--- a/net/mhttp/mhttp_middleware.go
+++ b/net/mhttp/mhttp_middleware.go
@@ -5,7 +5,7 @@ type MiddlewareFunc func(*Request)
 
 // Use adds global middleware.
 func (s *Server) Use(middlewares ...MiddlewareFunc) {
-	s.RouterGroup.Use(middlewares)
+	s.RouterGroup.Middleware(middlewares...)
 }
 
 // Middleware alias Use.

--- a/net/mhttp/mhttp_middleware_internal.go
+++ b/net/mhttp/mhttp_middleware_internal.go
@@ -96,12 +96,6 @@ func internalMiddlewareMetric() MiddlewareFunc {
 // internalMiddlewareTrace returns a middleware for OpenTelemetry tracing
 func internalMiddlewareTrace() MiddlewareFunc {
 	return func(r *Request) {
-		// If the default trace provider is used, do nothing.
-		if !mtrace.IsUsingMaltoseProvider() {
-			r.Next()
-			return
-		}
-
 		// Skip health check
 		if r.Request.URL.Path == r.server.config.HealthCheck {
 			r.Next()
@@ -134,7 +128,7 @@ func internalMiddlewareTrace() MiddlewareFunc {
 		)
 		defer span.End()
 
-		// Inject the updated context into the request.
+		// Inject the updated context into both Request objects
 		r.Request = r.Request.WithContext(ctx)
 
 		// process request

--- a/net/mhttp/mhttp_middleware_log.go
+++ b/net/mhttp/mhttp_middleware_log.go
@@ -9,7 +9,7 @@ import (
 	"github.com/graingo/maltose/os/mlog"
 )
 
-const maxBodySize = -1
+var LogMaxBodySize int = -1
 
 // responseWriter is a custom http.ResponseWriter that captures the response body and status.
 // It embeds gin.ResponseWriter to ensure full compatibility.
@@ -77,7 +77,7 @@ func MiddlewareLog() MiddlewareFunc {
 			requestFields = append(requestFields, mlog.String("query", raw))
 		}
 		if len(reqBodyBytes) > 0 {
-			requestFields = append(requestFields, mlog.String("request_body", getBodyString(reqBodyBytes, maxBodySize)))
+			requestFields = append(requestFields, mlog.String("request_body", getBodyString(reqBodyBytes, LogMaxBodySize)))
 		}
 
 		r.Logger().Infow(r.Request.Context(), "http server request started", requestFields...)
@@ -99,7 +99,7 @@ func MiddlewareLog() MiddlewareFunc {
 			mlog.Float64("latency_ms", float64(duration.Nanoseconds())/1e6),
 		)
 		if len(resBodyBytes) > 0 {
-			finalFields = append(finalFields, mlog.String("response_body", getBodyString(resBodyBytes, maxBodySize)))
+			finalFields = append(finalFields, mlog.String("response_body", getBodyString(resBodyBytes, LogMaxBodySize)))
 		}
 
 		// Decide log level based on errors or status code

--- a/net/mhttp/mhttp_middleware_log.go
+++ b/net/mhttp/mhttp_middleware_log.go
@@ -9,6 +9,8 @@ import (
 	"github.com/graingo/maltose/os/mlog"
 )
 
+const maxBodySize = 1024
+
 // responseWriter is a custom http.ResponseWriter that captures the response body and status.
 // It embeds gin.ResponseWriter to ensure full compatibility.
 type responseWriter struct {
@@ -75,7 +77,7 @@ func MiddlewareLog() MiddlewareFunc {
 			requestFields = append(requestFields, mlog.String("query", raw))
 		}
 		if len(reqBodyBytes) > 0 {
-			requestFields = append(requestFields, mlog.String("request_body", getBodyString(reqBodyBytes, 512)))
+			requestFields = append(requestFields, mlog.String("request_body", getBodyString(reqBodyBytes, maxBodySize)))
 		}
 
 		r.Logger().Infow(r.Request.Context(), "http server request started", requestFields...)
@@ -97,7 +99,7 @@ func MiddlewareLog() MiddlewareFunc {
 			mlog.Float64("latency_ms", float64(duration.Nanoseconds())/1e6),
 		)
 		if len(resBodyBytes) > 0 {
-			finalFields = append(finalFields, mlog.String("response_body", getBodyString(resBodyBytes, 512)))
+			finalFields = append(finalFields, mlog.String("response_body", getBodyString(resBodyBytes, maxBodySize)))
 		}
 
 		// Decide log level based on errors or status code

--- a/net/mhttp/mhttp_middleware_log.go
+++ b/net/mhttp/mhttp_middleware_log.go
@@ -9,7 +9,7 @@ import (
 	"github.com/graingo/maltose/os/mlog"
 )
 
-const maxBodySize = 1024
+const maxBodySize = -1
 
 // responseWriter is a custom http.ResponseWriter that captures the response body and status.
 // It embeds gin.ResponseWriter to ensure full compatibility.
@@ -120,6 +120,9 @@ func MiddlewareLog() MiddlewareFunc {
 func getBodyString(body []byte, limit int) string {
 	if len(body) == 0 {
 		return ""
+	}
+	if limit < 0 { // no limit
+		return string(body)
 	}
 	if len(body) > limit {
 		return string(body[:limit]) + "..."

--- a/net/mhttp/mhttp_middleware_log.go
+++ b/net/mhttp/mhttp_middleware_log.go
@@ -36,33 +36,36 @@ func (w *responseWriter) WriteString(s string) (int, error) {
 	return n, err
 }
 
-// MiddlewareLog is a middleware for logging HTTP requests.
+// MiddlewareLog is a middleware for logging HTTP requests in two steps:
+// 1. Before the handler is executed ("started").
+// 2. After the handler is completed ("finished").
+// This allows for better observability, especially for hanging or panicking requests.
 func MiddlewareLog() MiddlewareFunc {
 	return func(r *Request) {
-
 		// Skip health check
 		if r.Request.URL.Path == r.server.config.HealthCheck {
 			r.Next()
 			return
 		}
 
+		// --- Step 1: Log request start ---
+
 		start := time.Now()
 
-		// Safely read and capture the request body
+		// Safely read and capture the request body for logging, then restore it.
 		var reqBodyBytes []byte
 		if r.Request.Body != nil {
 			reqBodyBytes, _ = io.ReadAll(r.Request.Body)
-			r.Request.Body = io.NopCloser(bytes.NewBuffer(reqBodyBytes)) // Restore body
+			r.Request.Body = io.NopCloser(bytes.NewBuffer(reqBodyBytes))
 		}
 
-		// Create a response writer to capture the response
+		// Create a custom response writer to capture the response body and status.
 		writer := &responseWriter{
 			ResponseWriter: r.Writer,
 			body:           &bytes.Buffer{},
 		}
 		r.Writer = writer
 
-		// request fields
 		requestFields := mlog.Fields{
 			mlog.String("ip", r.ClientIP()),
 			mlog.String("method", r.Request.Method),
@@ -75,40 +78,38 @@ func MiddlewareLog() MiddlewareFunc {
 			requestFields = append(requestFields, mlog.String("request_body", getBodyString(reqBodyBytes, 512)))
 		}
 
-		// Log request
 		r.Logger().Infow(r.Request.Context(), "http server request started", requestFields...)
 
-		// Execute next middleware
+		// --- Step 2: Execute handler and log completion ---
+
 		r.Next()
 
-		// Now we have all the information, let's build the log fields
 		duration := time.Since(start)
 		status := writer.Status()
 		resBodyBytes := writer.body.Bytes()
 
 		msg := "http server request finished"
 
-		responseFields := mlog.Fields{
-			mlog.String("ip", r.ClientIP()),
-			mlog.String("method", r.Request.Method),
-			mlog.String("path", r.Request.URL.Path),
+		// The final log should contain all information for context.
+		// Start with the initial request fields and add response details.
+		finalFields := append(requestFields,
 			mlog.Int("status", status),
 			mlog.Float64("latency_ms", float64(duration.Nanoseconds())/1e6),
-		}
+		)
 		if len(resBodyBytes) > 0 {
-			responseFields = append(responseFields, mlog.String("response_body", getBodyString(resBodyBytes, 512)))
+			finalFields = append(finalFields, mlog.String("response_body", getBodyString(resBodyBytes, 512)))
 		}
 
 		// Decide log level based on errors or status code
 		if len(r.Errors) > 0 {
 			msg += " with errors"
 			// Log with the actual error from the context
-			r.Logger().Errorw(r.Request.Context(), r.Errors.Last().Err, msg, responseFields...)
+			r.Logger().Errorw(r.Request.Context(), r.Errors.Last().Err, msg, finalFields...)
 		} else if status >= 400 {
-			msg += " with error status"
-			r.Logger().Warnw(r.Request.Context(), msg, responseFields...)
+			msg += " with warning status"
+			r.Logger().Warnw(r.Request.Context(), msg, finalFields...)
 		} else {
-			r.Logger().Infow(r.Request.Context(), msg, responseFields...)
+			r.Logger().Infow(r.Request.Context(), msg, finalFields...)
 		}
 	}
 }

--- a/net/mhttp/mhttp_prebind.go
+++ b/net/mhttp/mhttp_prebind.go
@@ -19,35 +19,27 @@ type preBindItem struct {
 
 // bindRoutes binds all pre-bound routes.
 func (s *Server) bindRoutes(_ context.Context) {
-	processedGroups := make(map[*RouterGroup]bool)
-
-	// Step 1: Apply all group-level middlewares exactly once per group using ginGroup.Use().
 	for _, item := range s.preBindItems {
-		group := item.Group
-		if !processedGroups[group] {
-			processedGroups[group] = true
-			if len(group.middlewares) > 0 {
-				var ginMiddlewares []gin.HandlerFunc
-				for _, middleware := range group.middlewares {
-					m := middleware
-					ginMiddlewares = append(ginMiddlewares, func(c *gin.Context) {
-						m(newRequest(c, s))
-					})
-				}
-				group.ginGroup.Use(ginMiddlewares...)
-			}
+		var allHandlers []gin.HandlerFunc
+		var collectedMiddlewares []MiddlewareFunc
+
+		// Traverse up from the current group to the root, collecting middlewares.
+		for g := item.Group; g != nil; g = g.parent {
+			collectedMiddlewares = append(collectedMiddlewares, g.middlewares...)
 		}
-	}
 
-	// Step 2: Register all routes with their route-specific middlewares and the final handler.
-	// DO NOT add group middlewares here again.
-	for _, item := range s.preBindItems {
-		var routeHandlers []gin.HandlerFunc
+		// Reverse the collected middlewares to ensure parent middlewares run first.
+		for i := len(collectedMiddlewares) - 1; i >= 0; i-- {
+			m := collectedMiddlewares[i]
+			allHandlers = append(allHandlers, func(c *gin.Context) {
+				m(newRequest(c, s))
+			})
+		}
 
-		// ONLY handle route-level middlewares
+		// Add route-level middlewares
 		for _, middleware := range item.RouteMiddlewares {
 			m := middleware
-			routeHandlers = append(routeHandlers, func(c *gin.Context) {
+			allHandlers = append(allHandlers, func(c *gin.Context) {
 				m(newRequest(c, s))
 			})
 		}
@@ -56,17 +48,12 @@ func (s *Server) bindRoutes(_ context.Context) {
 		finalHandler := func(c *gin.Context) {
 			item.HandlerFunc(newRequest(c, s))
 		}
-		routeHandlers = append(routeHandlers, finalHandler)
+		allHandlers = append(allHandlers, finalHandler)
 
 		// register to Gin
-		item.Group.ginGroup.Handle(item.Method, item.Path, routeHandlers...)
+		item.Group.ginGroup.Handle(item.Method, item.Path, allHandlers...)
 	}
 
 	// clean pre-bind list
 	s.preBindItems = nil
-
-	// clean middleware references to help garbage collection
-	for group := range processedGroups {
-		group.middlewares = nil
-	}
 }

--- a/net/mhttp/mhttp_route.go
+++ b/net/mhttp/mhttp_route.go
@@ -6,6 +6,8 @@ import (
 	"reflect"
 	"sort"
 	"strings"
+
+	"github.com/gin-gonic/gin"
 )
 
 type routeType int
@@ -122,4 +124,11 @@ func (s *Server) printRoute(ctx context.Context) {
 	// Footer
 	footer := fmt.Sprintf("└─%s─┴─%s─┴─%s─┘\n\n", strings.Repeat("─", maxMethod), strings.Repeat("─", maxPath), strings.Repeat("─", maxHandler))
 	fmt.Print(footer)
+}
+
+func (s *Server) SetNoRouteHandler(handler HandlerFunc) {
+	s.engine.NoRoute(func(c *gin.Context) {
+		r := newRequest(c, s)
+		handler(r)
+	})
 }


### PR DESCRIPTION
对 `mhttp` 和 `mclient` 模块进行的一次大规模重构和功能增强，主要解决了中间件注册的核心问题，并全面提升了日志系统的可观察性。

#### **核心变更点：**

1.  **中间件注册与继承重构 (fix, refactor):**
    *   彻底修复了中间件注册的底层逻辑，确保全局、路由组和路由自身的中间件能被正确、无重复地应用，解决了此前处理器（handler）数量不符合预期的根本问题。
    *   重构了 `RouterGroup` 的中间件继承机制，采用父指针回溯的方式动态构建处理链，使其行为更健壮、更符合直觉。

2.  **日志系统可观察性增强 (feat):**
    *   将 `mhttp` (服务端) 和 `mclient` (客户端) 的日志记录模式统一重构为“两步法”（请求开始/请求结束），极大地提升了对挂起或慢速请求的监控和排查能力。
    *   新增了对 `404 Not Found` 路由的统一 JSON 响应处理，提升了 API 的健壮性和客户端友好性。

3.  **日志内容与调试体验优化 (feat):**
    *   日志中间件现已支持打印请求和响应的报文体（body）。
    *   将报文体的日志打印长度从硬编码改为可配置，通过设置 `maxBodySize` 为负数可以实现不截断、打印完整报文，极大地提升了开发和调试效率。